### PR TITLE
Integrate django rest framework

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
     "eslint.alwaysShowStatus": true,
     "eslint.lintTask.enable": true,
     "eslint.run": "onSave",
-    "python.pythonPath": "venv/bin/python",
+    "python.pythonPath": "backend/venv/bin/python",
     "python.linting.pylintEnabled": true,
     "python.linting.pylintArgs": ["--load-plugins", "pylint_django", "--disable", "missing-docstring"],
     "python.linting.enabled": true

--- a/backend/blog/models.py
+++ b/backend/blog/models.py
@@ -1,6 +1,19 @@
+from django.contrib.auth.models import User, Group
+from rest_framework import serializers
 from django.db import models
 from django.utils import timezone
 import datetime
+
+class UserSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = User
+        fields = ['url', 'username', 'email', 'groups']
+
+
+class GroupSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Group
+        fields = ['url', 'name']
 
 class Question(models.Model):
     question_text = models.CharField(max_length=200)

--- a/backend/blog/serializers.py
+++ b/backend/blog/serializers.py
@@ -1,0 +1,14 @@
+from django.contrib.auth.models import User, Group
+from rest_framework import serializers
+
+
+class UserSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = User
+        fields = ['url', 'username', 'email', 'groups']
+
+
+class GroupSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Group
+        fields = ['url', 'name']

--- a/backend/blog/urls.py
+++ b/backend/blog/urls.py
@@ -2,6 +2,8 @@ from django.urls import path
 
 from . import views
 
+app_name = 'blog'
+
 urlpatterns = [
     # ex: /polls/
     path('', views.index, name='index'),

--- a/backend/blog/urls.py
+++ b/backend/blog/urls.py
@@ -2,7 +2,6 @@ from django.urls import path
 
 from . import views
 
-app_name = 'blog'
 urlpatterns = [
     # ex: /polls/
     path('', views.index, name='index'),

--- a/backend/blog/views.py
+++ b/backend/blog/views.py
@@ -1,8 +1,29 @@
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
+from django.contrib.auth.models import User, Group
+from rest_framework import viewsets
+from rest_framework import permissions
+from .serializers import UserSerializer, GroupSerializer
 
 from .models import Question, Choice
+
+class UserViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows users to be viewed or edited.
+    """
+    queryset = User.objects.all().order_by('-date_joined')
+    serializer_class = UserSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+
+class GroupViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows groups to be viewed or edited.
+    """
+    queryset = Group.objects.all()
+    serializer_class = GroupSerializer
+    permission_classes = [permissions.IsAuthenticated]
 
 def index(request):
     latest_question_list = Question.objects.order_by('-pub_date')[:5]

--- a/backend/iletthedawgsout/settings.py
+++ b/backend/iletthedawgsout/settings.py
@@ -32,6 +32,7 @@ ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
     'blog.apps.BlogConfig',
+    'rest_framework',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -119,3 +120,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 
 STATIC_URL = '/static/'
+
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 10
+}

--- a/backend/iletthedawgsout/urls.py
+++ b/backend/iletthedawgsout/urls.py
@@ -1,7 +1,17 @@
 from django.contrib import admin
+from rest_framework import routers
 from django.urls import include, path
+from blog import views
 
+router = routers.DefaultRouter()
+router.register(r'users', views.UserViewSet)
+router.register(r'groups', views.GroupViewSet)
+
+# Wire up our API using automatic URL routing.
+# Additionally, we include login URLs for the browsable API.
 urlpatterns = [
+    path('', include(router.urls)),
+    path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     path('blog/', include('blog.urls')),
     path('admin/', admin.site.urls),
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,7 @@
 asgiref==3.2.7
 Django==3.0.5
+django-filter==2.2.0
+djangorestframework==3.11.0
+Markdown==3.2.1
 pytz==2020.1
 sqlparse==0.3.1


### PR DESCRIPTION
We should use DRF to expose a REST API that our react frontend can use to do things like enumerate blog posts, render blog post details page, and upvote

This PR integrate the DRF by following their tutorial
https://www.django-rest-framework.org/tutorial/quickstart

Closes #2 